### PR TITLE
Refactor commands 

### DIFF
--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Linux for PHP/Linux for Composer
+ *
+ * Copyright 2017 - 2020 Foreach Code Factory <lfphp@asclinux.net>
+ * Version 2.0.9
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @package    Linux for PHP/Linux for Composer
+ * @copyright  Copyright 2017 - 2020 Foreach Code Factory <lfphp@asclinux.net>
+ * @link       https://linuxforphp.net/
+ * @license    Apache License, Version 2.0, see above
+ * @license    http://www.apache.org/licenses/LICENSE-2.0
+ * @since 1.0.0
+ */
+
+namespace Linuxforcomposer\Command;
+
+use Symfony\Component\Console\Command\Command;
+
+abstract class BaseCommand extends Command
+{
+    public function __construct()
+    {
+        // you *must* call the parent constructor
+        parent::__construct();
+    }
+
+    // @codeCoverageIgnoreStart
+    protected function isWindows()
+    {
+        return strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
+    }
+
+    protected function isWindows10()
+    {
+        return strstr(php_uname('v'), 'Windows 10') !== false && php_uname('r') === '10.0';
+    }
+    // @codeCoverageIgnoreEnd
+}

--- a/src/Command/DockerCommitCommand.php
+++ b/src/Command/DockerCommitCommand.php
@@ -27,26 +27,19 @@
 
 namespace Linuxforcomposer\Command;
 
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Linuxforcomposer\Helper\LinuxForComposerProcess;
 
-class DockerCommitCommand extends Command
+class DockerCommitCommand extends BaseCommand
 {
     const LFPHPDEFAULTVERSION = DockerManageCommand::LFPHPDEFAULTVERSION;
 
     protected static $defaultName = 'docker:commit';
 
     protected $dockerCommitCommand = 'docker commit ';
-
-    public function __construct()
-    {
-        // you *must* call the parent constructor
-        parent::__construct();
-    }
 
     protected function configure()
     {
@@ -106,9 +99,9 @@ class DockerCommitCommand extends Command
 
         $commitImageProcess = new LinuxForComposerProcess($this->dockerCommitCommand);
 
-        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+        if ($this->isWindows()) {
             // @codeCoverageIgnoreStart
-            if (strstr(php_uname('v'), 'Windows 10') !== false && php_uname('r') == '10.0') {
+            if ($this->isWindows10()) {
                 $commitImageProcess->setDecorateWindows(true);
             } else {
                 $commitImageProcess->setDecorateWindowsLegacy(true);

--- a/src/Command/DockerRunCommand.php
+++ b/src/Command/DockerRunCommand.php
@@ -27,7 +27,6 @@
 
 namespace Linuxforcomposer\Command;
 
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -36,17 +35,11 @@ use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Linuxforcomposer\Helper\LinuxForComposerProcess;
 
-class DockerRunCommand extends Command
+class DockerRunCommand extends BaseCommand
 {
     const LFPHPCLOUDSERVER = 'https://linuxforphp.com/api/v1/deployments';
 
     protected static $defaultName = 'docker:run';
-
-    public function __construct()
-    {
-        // you *must* call the parent constructor
-        parent::__construct();
-    }
 
     protected function configure()
     {
@@ -235,11 +228,7 @@ class DockerRunCommand extends Command
                     && !empty($fileContentsArray['lfphp-cloud']['username'])
                     && !empty($fileContentsArray['lfphp-cloud']['token'])
                 ) {
-                    $account = $fileContentsArray['lfphp-cloud']['account'];
-
-                    $username = $fileContentsArray['lfphp-cloud']['username'];
-
-                    $token = $fileContentsArray['lfphp-cloud']['token'];
+                    ['account' => $account, 'username' => $username, 'token' => $token] = $fileContentsArray['lfphp-cloud'];
                 } else {
                     echo PHP_EOL
                         . PHP_EOL
@@ -388,9 +377,11 @@ class DockerRunCommand extends Command
         if ($returnCode > 1) {
             echo PHP_EOL . "Please check your 'Linux for Composer' JSON file for misconfigurations." . PHP_EOL . PHP_EOL;
             return $returnCode;
-        } elseif ($returnCode === 1) {
+        }
+
+        if ($returnCode === 1) {
             echo PHP_EOL . "The 'Linux for Composer' JSON file is invalid." . PHP_EOL . PHP_EOL;
-            return 1;
+            return $returnCode;
         }
 
         return explode("\n", $parseOutput->fetch());


### PR DESCRIPTION
Hi @andrewscaya, I hope you are well,

History: about a year ago, I expressed a [desire to work on improving your project](https://github.com/linuxforphp/linuxforcomposer/issues/1)... And finally, I start doing refactoring, although maybe it doesn't make much sense, because it's just refactoring :smiley: 

Anyway, this is only the first part of refactoring that I have planned. I want to split the codebase so that I end up making the commands easier to maintain and understand.

In this PR:

- Introduce base class for commands `BaseCommand` to reduce code duplication (methods for Windows).
- Use strict compassion everywhere
- Rename variables to match camelCase variables convention
- Minor improvements to naming methods and variables
- Use array destructuring (_this is controversial, but in the second step work I will think about it._)

Diff changes aren't  big, so it shouldn't be hard to examine. Please take some time for them, I want to continue what I started.
 